### PR TITLE
undefined variable "fieldKey" referenced for matrix blocks, added new…

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -128,6 +128,7 @@ class Service extends Component
 
         foreach ($originField->blockTypes as $i => $blockType) {
             $fields = [];
+            $blockKey = 'new' . ($i + 1);
 
             foreach ($blockType->getFields() as $j => $blockField) {
                 $fieldKey = 'new' . ($j + 1);
@@ -159,7 +160,7 @@ class Service extends Component
                 }
             }
 
-            $blockTypes[$fieldKey] = [
+            $blockTypes[$blockKey] = [
                 'name' => $blockType->name,
                 'handle' => $blockType->handle,
                 'sortOrder' => $blockType->sortOrder,


### PR DESCRIPTION
The cloning process was breaking on a Matrix field. I found this error in logs:

`2020-09-26 21:09:49 [-][3][-][error][yii\base\ErrorException:8] yii\base\ErrorException: Undefined variable: fieldKey in /Users/brianhamby/Projects/thayer_website/vendor/verbb/field-manager/src/services/Service.php:162`

Tracked it to a reference to an undefined variable "$fieldKey" (the variable is scoped inside a foreach loop that is inaccessible) and so I made a "$blockKey" variable to serve the purpose of the matrix block.