### PR TITLE
Fix error when importing Neo block type with `null` field layout

### DIFF
--- a/src/services/Import.php
+++ b/src/services/Import.php
@@ -247,6 +247,10 @@ class Import extends Component
 
         if (isset($settings['blockTypes'])) {
             foreach ($settings['blockTypes'] as $i => $blockType) {
+                if ($blockType['fieldLayout'] === null) {
+                    continue;
+                }
+
                 $fieldLayout = FieldManager::$plugin->getService()->createFieldLayoutFromConfig($blockType['fieldLayout']);
 
                 // Have to save it now, and apply the ID to the blockType, as Neo won't save it for us

--- a/src/templates/import/map.html
+++ b/src/templates/import/map.html
@@ -240,15 +240,17 @@
             </td>
         </tr>
 
-        {% set fieldLayout = craft.fieldManager.createFieldLayoutFromConfig(blockType.fieldLayout) %}
+        {% if blockType.fieldLayout is not null %}
+            {% set fieldLayout = craft.fieldManager.createFieldLayoutFromConfig(blockType.fieldLayout) %}
 
-        {% for blockTypeTabIndex, blockTypeFieldTab in fieldLayout.getTabs() %}
-            {% for fieldLayoutElementIndex, fieldLayoutElement in blockTypeFieldTab.elements %}
-                {% namespace 'settings[blockTypes][new' ~ blockIndex ~ '][fieldLayout][' ~ blockTypeTabIndex ~ '][' ~ fieldLayoutElementIndex ~ ']' %}
-                    {{ fieldManagerMacros.nestedFieldLayoutElement(fieldLayoutElement, index, blockTypeId, true) }}
-                {% endnamespace %}
+            {% for blockTypeTabIndex, blockTypeFieldTab in fieldLayout.getTabs() %}
+                {% for fieldLayoutElementIndex, fieldLayoutElement in blockTypeFieldTab.elements %}
+                    {% namespace 'settings[blockTypes][new' ~ blockIndex ~ '][fieldLayout][' ~ blockTypeTabIndex ~ '][' ~ fieldLayoutElementIndex ~ ']' %}
+                        {{ fieldManagerMacros.nestedFieldLayoutElement(fieldLayoutElement, index, blockTypeId, true) }}
+                    {% endnamespace %}
+                {% endfor %}
             {% endfor %}
-        {% endfor %}
+        {% endif %}
     {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
Neo block types have their field layout set to `null` if nothing existed on the block type's field layout when saving the Neo field. However, trying to import a Neo field with a block type that has a `null` field layout currently causes an error. This pull request fixes that error.

Fixes #82.