### PR TITLE
Fix Neo block type groups being moved to the clone field, instead of being cloned

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -48,7 +48,9 @@ class Service extends Component
 
         if (get_class($field) == 'benf\neo\Field') {
             $blockTypes = $this->processCloneNeo($originField);
+            $groups = $this->processCloneNeoGroups($originField);
             $field->blockTypes = $blockTypes;
+            $field->groups = $groups;
 
             // Reset the keys so we can get iterate
             $blockTypes = array_values($blockTypes);
@@ -241,6 +243,21 @@ class Service extends Component
         }
 
         return $blockTypes;
+    }
+
+    public function processCloneNeoGroups(FieldInterface $originField): array
+    {
+        $groups = [];
+
+        foreach ($originField->groups as $i => $group) {
+            $groups['new' . $i] = [
+                'name' => $group->name,
+                'sortOrder' => $group->sortOrder,
+                'alwaysShowDropdown' => $group->alwaysShowDropdown,
+            ];
+        }
+
+        return $groups;
     }
 
     public function processCloneSuperTable(FieldInterface $originField): array


### PR DESCRIPTION
Currently, when cloning a Neo field, any block type groups belonging to the original field get moved to the clone field, instead of being cloned. This is due to the `processCloneNeo()` service method cloning the block type data, but not also the group data. This pull request fixes the issue by adding a `processCloneNeoGroups()` method to clone the group data, so as not to change the expected returned data format of `processCloneNeo()`.