### PR TITLE
Fix : entry types audit

### DIFF
--- a/src/templates/audit/index.html
+++ b/src/templates/audit/index.html
@@ -85,7 +85,10 @@
                                 </th>
                             </tr>
 
-                            {% for field in tab.layout.customFields %}
+                            {% set elements = tab.elements|filter(e => e is instance of('craft\\fieldlayoutelements\\CustomField')) %}
+
+                            {% for element in elements %}
+                                {% set field = element.field %}
                                 <tr class="fields">
                                     <th>
                                         <span class="go">


### PR DESCRIPTION
In the audit page all the fields were repeated for each tab.
This fixes it