### PR TITLE
fix: import success flash message

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -334,7 +334,8 @@ class BaseController extends Controller
             $importErrors = FieldManager::$plugin->getImport()->import($fieldsToImport);
 
             if (!$importErrors) {
-                Craft::$app->getSession()->setNotice(Craft::t('field-manager', 'Imported successfully.'));
+                Craft::$app->getSession()->setSuccess(Craft::t('field-manager', 'Imported successfully.'));
+                return null;
             } else {
                 Craft::$app->getSession()->setError(Craft::t('field-manager', 'Error importing fields.'));
 


### PR DESCRIPTION
Before the fix, the success message was overridden by the `No fields imported.` message